### PR TITLE
image_number was always 1

### DIFF
--- a/IO/complex/read_complex_data.m
+++ b/IO/complex/read_complex_data.m
@@ -36,7 +36,7 @@ function [ complex_data, metadata ] = read_complex_data( filename, varargin )
 % //////////////////////////////////////////
 
 
-if ~exist('image_number','var')
+if nargin < 6
     image_number=1;
 else
     image_number=varargin{5};


### PR DESCRIPTION
In read_complex_data.m
The value of "image_number" would never reflect the user's input via "IMAGE_NUMBER." In the original, "~exist('image_number','var')" would always evaluate to TRUE because "image_number" did not exist in the scope of the function yet. (Or were you doing something with global variable scope that I do not understand?) "image_number" would always be assigned the value 1, regardless of user input. Changing the check to "nargin < 6" at least checks the number of user input arguments (including required "filename" variable).