### PR TITLE
hg_mitm_viewer.m: Include FPS in each GIF frame

### DIFF
--- a/Visualization/mitm_viewer/hg_mitm_viewer.m
+++ b/Visualization/mitm_viewer/hg_mitm_viewer.m
@@ -1242,7 +1242,8 @@ methods (Access = private)
                             else
                                 imwrite(rgb2gray(frame2im(fig_frame)),...
                                     [pathname filename],'gif',...
-                                    'WriteMode','append');
+                                    'WriteMode','append',...
+                                    'DelayTime',1/FPS);
                             end
                         end
                     catch


### PR DESCRIPTION
The imwrite function defaults to an animated GIF inter-frame delay time of 0.5 seconds. It appears that imwrite expects the user to set the inter-frame time for each frame when writing. Without this addition, the resulting animated GIF would return to 2 FPS after the first frame was written. Including this extra input argument for each frame written allows for the hard-coded 4 FPS to be applied to every frame.