### PR TITLE
Prevent Version node from being added to xml in sicdstruct2xml

### DIFF
--- a/IO/complex/sicd/sicdstruct2xml.m
+++ b/IO/complex/sicd/sicdstruct2xml.m
@@ -172,7 +172,7 @@ end
 
     function child_node = process_single_node(current_node, node_name, sicdmeta, schema_struct, index)
         % Handle special case fieldnames first
-        if any(strcmp(node_name,{'native','SICDVersion','NITF'})) % Non-spec fields added by MATLAB SAR Toolbox
+        if any(strcmp(node_name,{'native','SICDVersion','Version','NITF'})) % Non-spec fields added by MATLAB SAR Toolbox
             child_node = [];
         elseif strcmp(node_name,'ICP') % Special case: ICP Indexed by name rather than number
             ICP_fields = {'FRFC','FRLC','LRLC','LRFC'};


### PR DESCRIPTION
# Description
This PR attempts to address a bug that was noticed when trying to read then write a SICD: 

```matlab
>> [complex_data, metadata] = read_complex_data(input_sicd);
>> writer = SICDWriter('/data/tmp/output.sicd', metadata);
```
![image](https://user-images.githubusercontent.com/78438270/180280876-c8073d0d-0fec-4d25-8830-3f2c345554f6.png)

The erroneous Version node being described is present in the SICD xml root:
```xml
         ...
        <Krg2>6.226011015733206E+01</Krg2>
        <Kaz1>-2.263987187407596E-01</Kaz1>
        <Kaz2>2.263987187407596E-01</Kaz2>
    </PFA>
    <Version>1.1.0</Version>
</SICD>
```

This seems to be attributable to a fieldname mismatch between [`sicdxml2struct`](https://github.com/ngageoint/MATLAB_SAR/blob/0580dfb149db5705b50646638d0ea69fd15272f1/IO/complex/sicd/sicdxml2struct.m#L49) which adds a field called "Version" and [`sicdstruct2xml`](https://github.com/ngageoint/MATLAB_SAR/blob/0580dfb149db5705b50646638d0ea69fd15272f1/IO/complex/sicd/sicdstruct2xml.m#L175) which ignores a field called "SICDVersion".

I'm not sure if changing SICDVersion to Version in the `sicdstruct2xml` string comparison is sufficient/desired, but adding `Version` seemed like a safe fix.
