### PR TITLE
Adding get_nbdata

### DIFF
--- a/IO/phase_history/cphd/open_cphd_reader.m
+++ b/IO/phase_history/cphd/open_cphd_reader.m
@@ -142,6 +142,7 @@ end
 
 %% Specify reader object methods-- close() method already defined above
 readerobj.read_cphd = @read_data;
+readerobj.get_nbdata = @get_nbdata;
 readerobj.get_meta = @() xml_meta;
 
     %% READ_CPHD method of this reader object
@@ -176,10 +177,25 @@ readerobj.get_meta = @() xml_meta;
 
         % Copy selected vector-based data to a structure
         if nargout>1
-            fldnames = fieldnames(vbp_all);
-            for fn_index = 1:numel(fldnames)
-                nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
-            end
+            nbdata = get_nbdata(pulse_indices, channel);
+        end
+    end
+
+    %% Function for reading only the narrowband data
+    % Faster than calling read_data when you only want nbdata
+    function [nbdata] = get_nbdata(pulse_indices, channel)
+         % Compute default input parameters
+        if (nargin<3)
+            channel=1;
+        end
+        if (nargin<1)||strcmpi(pulse_indices,'all')
+            pulse_indices=1:double(xml_meta.Data.Channel(channel).NumVectors);
+        end
+
+        % read just the nb data
+        fldnames = fieldnames(vbp_all);
+        for fn_index = 1:numel(fldnames)
+            nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
         end
     end
 

--- a/IO/phase_history/cphd/open_cphd_reader.m
+++ b/IO/phase_history/cphd/open_cphd_reader.m
@@ -142,6 +142,7 @@ end
 
 %% Specify reader object methods-- close() method already defined above
 readerobj.read_cphd = @read_data;
+readerobj.get_nbdata = @get_nbdata;
 readerobj.get_meta = @() xml_meta;
 
     %% READ_CPHD method of this reader object
@@ -181,6 +182,17 @@ readerobj.get_meta = @() xml_meta;
                 nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
             end
         end
+    end
+
+    % Function to get only the nbdata
+    function [nbdata] = get_nbdata(pulse_indices, channel)
+        if (nargin<2)
+            channel = 1;
+        end
+        if (nargin<1)
+            pulse_indices = 'all';
+        end
+        [~, nbdata] = read_data(pulse_indices, [], channel);
     end
 
     %% Function for reading data with memory mapped files

--- a/IO/phase_history/cphd/open_cphd_reader.m
+++ b/IO/phase_history/cphd/open_cphd_reader.m
@@ -142,7 +142,6 @@ end
 
 %% Specify reader object methods-- close() method already defined above
 readerobj.read_cphd = @read_data;
-readerobj.get_nbdata = @get_nbdata;
 readerobj.get_meta = @() xml_meta;
 
     %% READ_CPHD method of this reader object
@@ -177,25 +176,10 @@ readerobj.get_meta = @() xml_meta;
 
         % Copy selected vector-based data to a structure
         if nargout>1
-            nbdata = get_nbdata(pulse_indices, channel);
-        end
-    end
-
-    %% Function for reading only the narrowband data
-    % Faster than calling read_data when you only want nbdata
-    function [nbdata] = get_nbdata(pulse_indices, channel)
-         % Compute default input parameters
-        if (nargin<3)
-            channel=1;
-        end
-        if (nargin<1)||strcmpi(pulse_indices,'all')
-            pulse_indices=1:double(xml_meta.Data.Channel(channel).NumVectors);
-        end
-
-        % read just the nb data
-        fldnames = fieldnames(vbp_all);
-        for fn_index = 1:numel(fldnames)
-            nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
+            fldnames = fieldnames(vbp_all);
+            for fn_index = 1:numel(fldnames)
+                nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
+            end
         end
     end
 

--- a/IO/phase_history/cphd30/open_cphd30_reader.m
+++ b/IO/phase_history/cphd30/open_cphd30_reader.m
@@ -65,6 +65,7 @@ meta=meta2cphdx_cphd30(cphd_preamble, all_nbdata); % Convert metadata to CPHDX f
 meta.native.cphd30 = cphd_preamble; % Save original format
 
 readerobj.read_cphd=@read_data;
+readerobj.get_nbdata =@get_nbdata;
 readerobj.get_meta=@() meta;
 readerobj.close=@() fclose(fid);
 
@@ -159,6 +160,18 @@ readerobj.close=@() fclose(fid);
             end
             % TODO: Compute offsets due to channel numbers
         end
+    end
+
+
+    % Function to get only the nbdata
+    function [nbdata] = get_nbdata(pulse_indices, channel)
+        if (nargin<2)
+            channel = 1;
+        end
+        if (nargin<1)
+            pulse_indices = 'all';
+        end
+        [~, nbdata] = read_data(pulse_indices, [], channel);
     end
 
     % Assumes a single channel dataset

--- a/IO/phase_history/crsd/open_crsd_reader.m
+++ b/IO/phase_history/crsd/open_crsd_reader.m
@@ -118,6 +118,7 @@ end
 
 %% Specify reader object methods-- close() method already defined above
 readerobj.read_raw = @read_data;
+readerobj.get_nbdata = @get_nbdata;
 readerobj.get_meta = @() xml_meta;
 
     %% READ_RAW method of this reader object
@@ -157,6 +158,17 @@ readerobj.get_meta = @() xml_meta;
                 nbdata.(fldnames{fn_index}) = vbp_all(channel).(fldnames{fn_index})(pulse_indices,:);
             end
         end
+    end
+
+    % Function to get only the nbdata
+    function [nbdata] = get_nbdata(pulse_indices, channel)
+        if (nargin<2)
+            channel = 1;
+        end
+        if (nargin<1)
+            pulse_indices = 'all';
+        end
+        [~, nbdata] = read_data(pulse_indices, [], channel);
     end
 
     %% Function for reading data with memory mapped files

--- a/IO/phase_history/gotcha/gotcha_public_release/open_gotchapr_reader.m
+++ b/IO/phase_history/gotcha/gotcha_public_release/open_gotchapr_reader.m
@@ -123,11 +123,12 @@ cphd_meta.ReferenceGeometry.SRP.ECF.Z = SRP_ECEF(3);
 
 %% Setup reader object
 readerobj.read_cphd=@read_data; 
+readerobj.get_nbdata =@get_nbdata;
 readerobj.get_meta=@() cphd_meta;
 readerobj.close=@() 1;
 
     %% Functino for READ_CPHD method
-    function [wbvectors, nbdata] = read_data(pulse_indices, sample_indices, channels)
+    function [wbvectors, nbdata] = read_data(pulse_indices, sample_indices)
         % Parse input parameters
         if (nargin<1)||strcmpi(pulse_indices,'all')
             pulse_indices=1:cphd_meta.Data.Channel.NumVectors;
@@ -147,6 +148,17 @@ readerobj.close=@() 1;
         for i=1:length(nb_fieldnames)
             nbdata.(nb_fieldnames{i}) = all_nbdata.(nb_fieldnames{i})(pulse_indices,:);
         end
+    end
+
+    % Function to get only the nbdata
+    function [nbdata] = get_nbdata(pulse_indices, channel)
+        if (nargin<2)
+            channel = 1;
+        end
+        if (nargin<1)
+            pulse_indices = 'all';
+        end
+        [~, nbdata] = read_data(pulse_indices, [], channel);
     end
 
 end

--- a/IO/phase_history/open_ph_reader.m
+++ b/IO/phase_history/open_ph_reader.m
@@ -65,13 +65,6 @@ if isempty(format_string)
 end
 readerobj = eval(['open_' format_string '_reader(''' filename ''', varargin{:});']);
 
-% Define the get_nbdata for each reader object
-if exist(ro,'read_cphd')
-    readerobj.get_nbdata = ro.read_cphd('all', []);
-elseif exist(ro,'read_raw')
-    readerobj.get_nbdata = ro.read_raw('all', []);
-end
-
 end
 
 % //////////////////////////////////////////

--- a/IO/phase_history/open_ph_reader.m
+++ b/IO/phase_history/open_ph_reader.m
@@ -65,6 +65,13 @@ if isempty(format_string)
 end
 readerobj = eval(['open_' format_string '_reader(''' filename ''', varargin{:});']);
 
+% Define the get_nbdata for each reader object
+if exist(ro,'read_cphd')
+    readerobj.get_nbdata = ro.read_cphd('all', []);
+elseif exist(ro,'read_raw')
+    readerobj.get_nbdata = ro.read_raw('all', []);
+end
+
 end
 
 % //////////////////////////////////////////


### PR DESCRIPTION
Allows users to request nbdata without needing to also get wbdata. This is particularly useful if you have a large CPHD file and you only want to look at the narrowband data.