### PR TITLE
Fix cphd optional pvp read

### DIFF
--- a/IO/phase_history/cphd/convert_to_cphd.m
+++ b/IO/phase_history/cphd/convert_to_cphd.m
@@ -280,14 +280,27 @@ function write_cphd_vbmeta(cphd_fid, cphd_meta, nbdata)
         vectorParametersFlatten = rmfield(vectorParametersFlatten, 'RcvAntenna');
         vectorParametersFlatten = setstructfields(vectorParametersFlatten, cphd_meta.PVP.RcvAntenna);
     end
+    if isfield(vectorParametersFlatten, 'AddedPVP')
+        vectorParametersFlatten = rmfield(vectorParametersFlatten, 'AddedPVP');
+        for i = 1:numel(cphd_meta.PVP.AddedPVP)
+            try
+              addedPVP = cphd_meta.PVP.AddedPVP{i};
+            catch
+              addedPVP = cphd_meta.PVP.AddedPVP(i);
+            end
+            vectorParametersFlatten.(addedPVP.Name).Offset = addedPVP.Offset;
+            vectorParametersFlatten.(addedPVP.Name).Size = addedPVP.Size;
+            vectorParametersFlatten.(addedPVP.Name).Format = addedPVP.Format;
+        end
+    end
     if isfield(vectorParametersFlatten,'TxPulse')
         vectorParametersFlatten = rmfield(vectorParametersFlatten, 'TxPulse');
         vectorParametersFlatten = setstructfields(vectorParametersFlatten, cphd_meta.PVP.TxPulse);
     end
     if isfield(vectorParametersFlatten,'TxAntenna')
         vectorParametersFlatten = rmfield(vectorParametersFlatten, 'TxAntenna');
-        vectorParametersFlatten = setstructfields(vectorParametersFlatten, cphd_meta.PVP.TxPulse.TxAntenna);
-    end
+        vectorParametersFlatten = setstructfields(vectorParametersFlatten, cphd_meta.PVP.TxAntenna);
+    end    
     vectorParametersCell = fieldnames(vectorParametersFlatten);
     vb_array = zeros(cphd_meta.Data.NumBytesPVP/8,length(nbdata.TxTime));
     for i = 1:length(vectorParametersCell)

--- a/IO/phase_history/cphd/open_cphd_reader.m
+++ b/IO/phase_history/cphd/open_cphd_reader.m
@@ -42,6 +42,27 @@ end
 % from file the vector-based metadata for the selected vectors, but it
 % hardly seems necessary as fast as this goes.
 vectorParametersFlatten = xml_meta.PVP;
+if isfield(vectorParametersFlatten,'RcvAntenna')
+    vectorParametersFlatten = rmfield(vectorParametersFlatten, 'RcvAntenna');
+    vectorParametersFlatten = setstructfields(vectorParametersFlatten, xml_meta.PVP.RcvAntenna);
+end
+if isfield(vectorParametersFlatten, 'AddedPVP')
+    vectorParametersFlatten = rmfield(vectorParametersFlatten, 'AddedPVP');
+    for i = 1:numel(xml_meta.PVP.AddedPVP)
+        try
+          addedPVP = xml_meta.PVP.AddedPVP{i};
+        catch
+          addedPVP = xml_meta.PVP.AddedPVP(i);
+        end
+        vectorParametersFlatten.(addedPVP.Name).Offset = addedPVP.Offset;
+        vectorParametersFlatten.(addedPVP.Name).Size = addedPVP.Size;
+        vectorParametersFlatten.(addedPVP.Name).Format = addedPVP.Format;
+    end
+end
+if isfield(vectorParametersFlatten,'TxAntenna')
+    vectorParametersFlatten = rmfield(vectorParametersFlatten, 'TxAntenna');
+    vectorParametersFlatten = setstructfields(vectorParametersFlatten, xml_meta.PVP.TxAntenna);
+end
 vectorParametersCell = fieldnames(vectorParametersFlatten);
 % Iterate through channels to extract vector-based metadata
 BYTES_PER_ELEMENT = 8; % Everything in vector-based metadata is of type double
@@ -55,30 +76,9 @@ for i = 1:xml_meta.Data.NumCPHDChannels
     vb_array = fread(fid, [(xml_meta.Data.NumBytesPVP/BYTES_PER_ELEMENT) xml_meta.Data.Channel(i).NumVectors], 'double');
     % Distribute vector-based metadata into a structure
     for j = 1:numel(vectorParametersCell)
-        if(contains(vectorParametersCell{j},'AddedPVP'))
-            for jj = 1:numel(xml_meta.PVP.(vectorParametersCell{j}))
-                try
-                    vbp_all(i).(xml_meta.PVP.(vectorParametersCell{j}){jj}.Name) = ...
-                    vb_array(xml_meta.PVP.(vectorParametersCell{j}){jj}.Offset+...
-                    (1:xml_meta.PVP.(vectorParametersCell{j}){jj}.Size),:).';
-                catch
-                    vbp_all(i).(xml_meta.PVP.(vectorParametersCell{j}).Name) = ...
-                    vb_array(xml_meta.PVP.(vectorParametersCell{j}).Offset+...
-                    (1:xml_meta.PVP.(vectorParametersCell{j}).Size),:).';
-                end
-            end
-        elseif(contains(vectorParametersCell{j},{'TxAntenna','RcvAntenna'}))
-            antennaVectorParametersCell = fieldnames(xml_meta.PVP.(vectorParametersCell{j}));
-            for jj = 1:numel(antennaVectorParametersCell)
-                vbp_all(i).(vectorParametersCell{j}).(antennaVectorParametersCell{jj}) = ...
-                vb_array(xml_meta.PVP.(vectorParametersCell{j}).(antennaVectorParametersCell{jj}).Offset+...
-                (1:xml_meta.PVP.(vectorParametersCell{j}).(antennaVectorParametersCell{jj}).Size),:).';
-            end
-        else
-            vbp_all(i).(vectorParametersCell{j}) = ...
-            vb_array(xml_meta.PVP.(vectorParametersCell{j}).Offset+...
-            (1:xml_meta.PVP.(vectorParametersCell{j}).Size),:).';
-        end
+        vbp_all(i).(vectorParametersCell{j}) = ...
+            vb_array(vectorParametersFlatten.(vectorParametersCell{j}).Offset+...
+            (1:vectorParametersFlatten.(vectorParametersCell{j}).Size),:).';
     end
 end
 

--- a/IO/phase_history/crsd/open_crsd_reader.m
+++ b/IO/phase_history/crsd/open_crsd_reader.m
@@ -47,7 +47,7 @@ if isfield(vectorParametersFlatten,'TxPulse')
 end
 if isfield(vectorParametersFlatten,'TxAntenna')
     vectorParametersFlatten = rmfield(vectorParametersFlatten, 'TxAntenna');
-    vectorParametersFlatten = setstructfields(vectorParametersFlatten, xml_meta.PVP.TxPulse.TxAntenna);
+    vectorParametersFlatten = setstructfields(vectorParametersFlatten, xml_meta.PVP.TxAntenna);
 end
 vectorParametersCell = fieldnames(vectorParametersFlatten);
 % Iterate through channels to extract vector-based metadata


### PR DESCRIPTION
Read optional PVP fields using the flattened structure (vectorParametersFlatten) similar to the CRSD code. That makes the for-loop a lot simpler. I also moved support for the AddedPVP from the for-loop to the flattened structure. 

Note this keeps the PVP data structure to a single layer. 

Previous => New
pvp.TxAntenna.TxACX => pvp.TxACX
pvp.TxAntenna.TxACY => pvp.TxACY
pvp.TxAntenna.TxEB=> pvp.TxEB
pvp.RcvAntenna.RcvACX => pvp.RcvACX
...

The new format seemed to be what write_cphd_vbmeta is expecting. 

Also some other fixes. I'm pretty sure that xml_meta.PVP.TxPulse.TxAntenna should be xml_meta.PVP.TxAntenna but I don't have any CRSD data to check and the draft standard I have doesn't include TxAntenna at all. This would be correct for CPHD data. Also added code to handle AddedPVP when outputting CPHD (previously caused an error).